### PR TITLE
Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "✅ Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/Loony2392/ha_hacs_divera_247/security/code-scanning/53](https://github.com/Loony2392/ha_hacs_divera_247/security/code-scanning/53)

In general, the fix is to explicitly define a `permissions` block for the workflow or for the individual job so that the `GITHUB_TOKEN` has only the minimal access required. For a read-only validation workflow that just checks out code and runs `hassfest`, `contents: read` is sufficient in almost all cases.

The best fix here, without changing existing functionality, is to add a `permissions` block at the workflow root (top level) so it applies to all jobs, including `validate`. Concretely, in `.github/workflows/hassfest.yml`, add:

```yaml
permissions:
  contents: read
```

right after the `on:` block (or before `on:` if you prefer; both are valid as top-level keys). This will ensure that the `GITHUB_TOKEN` used by `actions/checkout@v6` and `home-assistant/actions/hassfest@master` only has read access to repository contents. No imports, methods, or additional definitions are required since this is just a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
