### PR TITLE
Potential fix for code scanning alert no. 52: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: "✅ Hassfest Validation"


### PR DESCRIPTION
Potential fix for [https://github.com/Loony2392/ha_hacs_divera_247/security/code-scanning/52](https://github.com/Loony2392/ha_hacs_divera_247/security/code-scanning/52)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, limiting `GITHUB_TOKEN` to the least privileges required. For this validation workflow, read-only access to repository contents is sufficient, so `contents: read` is an appropriate minimal setting.

The best way to fix this without changing functionality is to add a root-level `permissions` block, applying to all jobs in this workflow. Insert it after the `on:` section (lines 3–7) and before `jobs:` (line 9). Set `contents: read`, which will still allow `actions/checkout` and the hassfest action to read the repo contents but will prevent unintended write operations using `GITHUB_TOKEN`. No imports or additional methods are needed; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a root-level permissions block to the hassfest workflow to limit GITHUB_TOKEN to contents: read.